### PR TITLE
audio: add code to make browser block play nicely with the audio block

### DIFF
--- a/generic/Dockerfile.template
+++ b/generic/Dockerfile.template
@@ -34,5 +34,9 @@ RUN usermod -a -G audio,video,tty chromium
 
 RUN ln -s /usr/bin/chromium /usr/bin/chromium-browser
 
+# Set up the audio block. This won't have any effect if the audio block is not being used.
+RUN curl -skL https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh| sh
+ENV PULSE_SERVER=tcp:audio:4317
+
 ENTRYPOINT ["bash", "start.sh"]
 CMD ["export DISPLAY=:0"]

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,27 @@ services:
       - "80"
 ```
 
+## Choosing audio output device
+By default the `browser` block will output audio via HDMI. If you want to route audio through a different interface you can do it with the help of the [`audio` block]((https://github.com/balenablocks/audio)). The `browser` block is pre-configured to use it if present so you only need to add it to your `docker-compose.yml` file and then use `AUDIO_OUTPUT` environment variable to select the desired output. Check out the `audio` block [documentation](https://github.com/balenablocks/audio#environment-variables) to learn more about it.
+
+In this example we add the `audio` block and route the `browser` audio to the Raspberry Pi headphone jack:
+
+```yaml
+services:
+  browser:
+    image: balenablocks/browser:raspberrypi4-64
+    network_mode: host
+  audio:
+    image: balenablocks/audio:raspberrypi4-64
+    privileged: true
+    ports:
+      - 4317:4317
+    environment:
+      AUDIO_OUTPUT: RPI_HEADPHONES
+```
+
+**Note**: The `browser` block expects the `audio` block to be named as such. If you change it's service name you'll need to override the `PULSE_SERVER` environment variable value to match it in the `browser` dockerfile. For example add `ENV PULSE_SERVER=tcp:not-audio:4317`.
+
 ## Supported devices
 The `browser` block has been tested to work on the following devices:
 

--- a/rpi/Dockerfile.template
+++ b/rpi/Dockerfile.template
@@ -32,5 +32,9 @@ COPY ../public-html /home/chromium
 RUN echo 'SUBSYSTEM=="vchiq",GROUP="video",MODE="0660"' > /etc/udev/rules.d/10-vchiq-permissions.rules
 RUN usermod -a -G audio,video,tty chromium
 
+# Set up the audio block. This wont't have any effect if the audio block is not being used.
+RUN curl -skL https://raw.githubusercontent.com/balenablocks/audio/master/scripts/alsa-bridge/debian-setup.sh| sh
+ENV PULSE_SERVER=tcp:audio:4317
+
 ENTRYPOINT ["bash", "start.sh"]
 CMD ["export DISPLAY=:0"]

--- a/start.sh
+++ b/start.sh
@@ -78,6 +78,11 @@ fi
 #create start script for X11
 echo "#!/bin/bash" > /home/chromium/xstart.sh
 
+# Configure audio block server
+# This won't have any effect if not using the audio block
+PULSE_SERVER=${PULSE_SERVER:-tcp:audio:4317}
+echo "export PULSE_SERVER=$PULSE_SERVER" >> /home/chromium/xstart.sh
+
 # if no window size has been specified, find the framebuffer size and use that
 if [[ -z ${WINDOW_SIZE+x} ]]
   then


### PR DESCRIPTION
This PR adds compatibility with the audio block, namely:
- setup ALSA bridge
- setup required env vars (`PULSE_SERVER=tcp:audio:4317`)

If not using the `audio` block the ALSA bridge can be safely ignored and audio will continue to work as intended.
`PULSE_SERVER` env var can be overriden if the default does not match the "audio" service name.

If using the `audio` block, you can now use `AUDIO_OUTPUT` to select output device.

Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>