### PR TITLE
Fix generation of environment variable list

### DIFF
--- a/src/start.sh
+++ b/src/start.sh
@@ -46,7 +46,7 @@ rm -f /data/chromium/SingletonLock
 # we can't maintain the environment with su, because we are logging in to a new session
 # so we need to manually pass in the environment variables to maintain, in a whitelist
 # This gets the current environment, as a comma-separated string
-environment=$(env | grep -v -w '_' | awk -F: '{ st = index($0,"=");print substr($1,0,st) ","}' | tr -d "\n")
+environment=$(env | grep -v -w '_' | awk -F= '{ st = index($0,"=");print substr($1,0,st) ","}' | tr -d "\n")
 # remove the last comma
 environment="${environment::-1}"
 


### PR DESCRIPTION
The command below in `src/start.sh` appends an "=" to each environment variable name in the generated list:

    $ env | grep -v -w '_' | awk -F: '{ st = index($0,"=");print substr($1,0,st) ","}' | tr -d "\n"
    SHELL=,SESSION_MANAGER=,QT_ACCESSIBILITY=,COLORTERM=, ...

Changing the argument to `awk -F` removes the "=", as required by `su -w`

    $ env | grep -v -w '_' | awk -F= '{ st = index($0,"=");print substr($1,0,st) ","}' | tr -d "\n"
    SHELL,SESSION_MANAGER,QT_ACCESSIBILITY,COLORTERM, ...

Partial fix for #90