### PR TITLE
Support touch input rotation

### DIFF
--- a/Dockerfile.raspberrypi
+++ b/Dockerfile.raspberrypi
@@ -14,6 +14,7 @@ RUN install_packages \
     xserver-xorg-legacy \
     xserver-xorg-video-fbdev \
     xserver-xorg xinit \
+    xinput \
     xterm 
 
 WORKDIR /usr/src/app

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,6 +13,7 @@ RUN install_packages \
     xserver-xorg-legacy \
     xserver-xorg-video-fbdev \
     xserver-xorg xinit \
+    xinput \
     xterm 
 
 WORKDIR /usr/src/app

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ The following environment variables allow configuration of the `browser` block:
 |`FLAGS`|[many!](https://peter.sh/experiments/chromium-command-line-switches/)|N/A|Overrides the flags chromium is started with. Enter a space (\' \') separated list of flags (e.g. `--noerrdialogs --disable-session-crashed-bubble`) <br/> **Use with caution!**|
 |`PERSISTENT`|`0`, `1`|`0`|Enables/disables user profile data being stored on the device. **Note: you'll need to create a settings volume. See example above** <br/> `0` = off, `1` = on|
 |`ROTATE_DISPLAY`|`normal`, `left`, `right`, `inverted`|`normal`|Rotates the display|
+|`TOUCHSCREEN`|`string`|N\A|Name of Touch Input to rotate|
 |`ENABLE_GPU`|`0`, `1`|0|Enables the GPU rendering. Necessary for Pi3B+ to display YouTube videos. <br/> `0` = off, `1` = on|
 |`WINDOW_SIZE`|`x,y`|Detected screen resolution|Sets the browser window size, such as `800,600`. <br/> **Note:** Reverse the dimensions if you also rotate the display to `left` or `right` |
 |`WINDOW_POSITION`|`x,y`|`0,0`|Specifies the browser window position on the screen|

--- a/src/startx.sh
+++ b/src/startx.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "--- List Input Devices ---"
+xinput list
+echo "----- End of List --------"
+
 function reverse_window_coordinates () {
   local INPUT=$1
 
@@ -9,6 +13,18 @@ function reverse_window_coordinates () {
   else
     echo "Screen coordinates not set correctly, so cannot reverse them."
   fi 
+}
+
+function rotate_touch () {
+  echo "Rotating Input ($1): $2"
+  local TRANSFORM='Coordinate Transformation Matrix'
+
+  case "$2" in
+    normal)   xinput set-prop "$1" "$TRANSFORM" 1 0 0 0 1 0 0 0 1;;
+    inverted) xinput set-prop "$1" "$TRANSFORM" -1 0 1 0 -1 1 0 0 1;;
+    left)     xinput set-prop "$1" "$TRANSFORM" 0 -1 1 1 0 0 0 0 1;;
+    right)    xinput set-prop "$1" "$TRANSFORM" 0 1 0 -1 0 1 0 0 1;;
+  esac
 }
 
 if [[ -z "$WINDOW_SIZE" ]]; then
@@ -41,6 +57,16 @@ if [[ ! -z "$ROTATE_DISPLAY" ]]; then
       export WINDOW_POSITION=$REVERSED_POSITION
       echo "Reversed window position: $WINDOW_POSITION"
     fi
+  fi
+
+  echo "Rotate Touch Inputs"
+  if [[ ! -z "$TOUCHSCREEN" ]]; then
+    rotate_touch "$TOUCHSCREEN" "$ROTATE_DISPLAY"
+  else
+    devices=$( xinput --list | fgrep Touch | sed -E 's/^.*id=([0-9]+).*$/\1/' )
+    for device in ${devices} ;do
+        rotate_touch $device $ROTATE_DISPLAY
+    done
   fi
 fi
 


### PR DESCRIPTION
This will fix rotation bugs for touch input devices, when `ROTATE_DISPLAY` is set.

It will try to find the Input Devices with `Touch` in their name.
But some devices use different names so the `TOUCHSCREEN` variable can be set to the name of the device.
I had for example a `QDtech MPI7003` that I have tested it with.

In only tested it on a RPi4 with the manual part via `TOUCHSCREEN` variable.

This is based on https://gist.github.com/mildmojo/48e9025070a2ba40795c and https://gist.github.com/mildmojo/48e9025070a2ba40795c#gistcomment-3729827

Change-type: minor