### PR TITLE
Use chrome-launcher's userDataDir

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -139,11 +139,6 @@ let launchChromium = async function(url) {
       }
     }
 
-    if ('1' === PERSISTENT_DATA)
-    {
-      flags.push('--user-data-dir=/data/chromium');
-    }
-
     let startingUrl = url;
     if ('1' === kioskMode)
     {
@@ -163,6 +158,7 @@ let launchChromium = async function(url) {
       ignoreDefaultFlags: true,
       chromeFlags: flags,
       port: REMOTE_DEBUG_PORT,
+      userDataDir: '1' === PERSISTENT_DATA ? '/data/chromium' : undefined
     });
       
     console.log(`Chromium remote debugging tools running on port: ${chrome.port}`);


### PR DESCRIPTION
The current implementation leads to log files being written to another directory because of https://github.com/GoogleChrome/chrome-launcher/blob/30755cde8627b7aad6caff1594c9752f80a39a4d/src/chrome-launcher.ts#L211.

This uses chrome-launcher's userDataDir prop instead of the custom flag. It works because chrome-launcher sets the same flag that was previously being set; see: https://github.com/GoogleChrome/chrome-launcher/blob/30755cde8627b7aad6caff1594c9752f80a39a4d/src/chrome-launcher.ts#L175