### PR TITLE
Added the ability to sent custom options to the "xset" command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ The following environment variables allow configuration of the `browser` block:
 |`WINDOW_POSITION`|`x,y`|`0,0`|Specifies the browser window position on the screen|
 |`API_PORT`|port number|5011|Specifies the port number the API runs on|
 |`REMOTE_DEBUG_PORT`|port number|35173|Specifies the port number the chrome remote debugger runs on|
+|`XSET_COMMAND`|`string`|`s off -dpms`|Specifies the xset commandline options.  Example:  `s 30 30 dpms 30 30 30` will turn on the screensaver and turn off the display using dpms after 30 seconds.|
 
 ---
 

--- a/src/startx.sh
+++ b/src/startx.sh
@@ -78,7 +78,12 @@ sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"/
 export VERSION=`chromium-browser --version`
 echo "Installed browser version: $VERSION"
 
-# stop the screen blanking
-xset s off -dpms
+if [[ ! -z $XSET_COMMAND ]]
+  then
+    xset $XSET_COMMAND
+  else
+    # stop the screen blanking by default
+    xset s off -dpms
+fi
 
 node /usr/src/app/server.js


### PR DESCRIPTION
This should allow more granular control of dpms and other xset options.

The full commandset for xset is available, as this just sends whatever you specify in the XSET_COMMAND to the xset command in startx.sh.