### PR TITLE
POST to set /kiosk/{value}

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ Returns whether the device is running kiosk mode or not:
 | 0 | disabled |
 | 1 | enabled |
 
-#### **PUT** /kiosk/{value}
+#### **POST** /kiosk/{value}
 Enables or disables kiosk mode
 
 | Value | Description |


### PR DESCRIPTION
I noticed that PUT doesn't work for /kiosk/{value} as per the curl error below. POST works fine.

mint@mint:~$ curl -X PUT http://x.x.x.x:5011/kiosk/0
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot PUT /kiosk/0</pre>
</body>
</html>
