### PR TITLE
Add a new kill endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,9 @@ You can also pre-set the kiosk and GPU settings as part of a URL put request. Ex
 curl --data "url=www.balena.io&gpu=0&kiosk=1" http://localhost:5011/url
 ```
 
+#### **POST** /kill
+Kills the chromium browser
+
 #### **GET** /gpu
 Returns the status of the GPU:
 

--- a/src/server.js
+++ b/src/server.js
@@ -271,6 +271,12 @@ app.post('/refresh', (req, res) => {
   return res.status(200).send('ok');
 });
 
+// kill endpoint
+app.post('/kill', (req, res) => {
+  chromeLauncher.killAll();
+  return res.status(200).send('ok');
+});
+
 // gpu set endpoint
 app.post('/gpu/:gpu', (req, res) => {
   if (!req.params.gpu) {


### PR DESCRIPTION
This PR will add a new `POST` endpoint `/kill` which will close any instances of the chromium browser, resulting in a blank screen.

Resolves issue: #128 